### PR TITLE
`trace_id` and `span_id` must be integers.

### DIFF
--- a/lib/traces/backend/datadog/interface.rb
+++ b/lib/traces/backend/datadog/interface.rb
@@ -44,8 +44,9 @@ module Traces
 				def trace_context=(context)
 					if context
 						::Datadog.tracer.provider.context = ::Datadog::Context.new(
-							trace_id: context.trace_id,
-							span_id: context.parent_id,
+							# We force these to be integers otherwise Datadog can fail internally:
+							trace_id: context.trace_id.to_i,
+							span_id: context.parent_id.to_i,
 							sampled: context.sampled?,
 						)
 					end

--- a/lib/traces/backend/datadog/version.rb
+++ b/lib/traces/backend/datadog/version.rb
@@ -23,7 +23,7 @@
 module Traces
 	module Backend
 		module Datadog
-			VERSION = "0.2.0"
+			VERSION = "0.2.1"
 		end
 	end
 end

--- a/spec/traces/backend/datadog_spec.rb
+++ b/spec/traces/backend/datadog_spec.rb
@@ -83,6 +83,17 @@ RSpec.describe Traces::Backend::Datadog do
 					span_id: context.parent_id
 				)
 			end
+			
+			it "can round-trip trace context" do
+				parsed_context = Traces::Context.parse(context.to_s)
+				
+				instance.trace_context = parsed_context
+				
+				expect(::Datadog.tracer.provider.context).to have_attributes(
+					trace_id: context.trace_id,
+					span_id: context.parent_id
+				)
+			end
 		end
 	end
 	


### PR DESCRIPTION
## Description

```
E, [2022-02-03T16:50:08.788307 #113720] ERROR -- ddtrace: [ddtrace] (/home/samuel/.gem/ruby/2.7.4/gems/ddtrace-0.54.2/lib/ddtrace/transport/http/client.rb:37:in `rescue in send_request') Internal error during HTTP transport request. Cause: 783: unexpected token at 'msgp: attempted to decode type "str" with method for "int" at 4/0/ParentID
```

This error can occur when transferring a trace context using `Traces::Context.parse` which expects `trace_id` and `span_id` to be String instance, but Datadog expects Integer values.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
