### PR TITLE
Restore monkey patch introducing `[]` and `[]=` to span instances.

### DIFF
--- a/lib/traces/backend/datadog/interface.rb
+++ b/lib/traces/backend/datadog/interface.rb
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-require 'ddtrace'
+require 'datadog/tracing'
 
 require 'traces/context'
 require_relative 'version'

--- a/lib/traces/backend/datadog/interface.rb
+++ b/lib/traces/backend/datadog/interface.rb
@@ -25,6 +25,12 @@ require 'ddtrace'
 require 'traces/context'
 require_relative 'version'
 
+# We introduce some compatibility interfaces for getting and setting tags:
+module Datadog::Tracing::Metadata::Tagging
+	alias []= set_tag
+	alias [] get_tag
+end
+
 module Traces
 	module Backend
 		module Datadog

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,12 +20,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-require 'datadog/tracing'
+require 'ddtrace'
 
-Datadog.configure do |config|
-	# To enable debug mode
-	# config.diagnostics.debug = true
-end
+# Datadog.configure do |config|
+# 	# To enable debug mode
+# 	config.diagnostics.debug = true
+# end
 
 require "bundler/setup"
 require "traces/backend/datadog"

--- a/spec/traces/backend/datadog_spec.rb
+++ b/spec/traces/backend/datadog_spec.rb
@@ -66,6 +66,14 @@ RSpec.describe Traces::Backend::Datadog do
 			
 			it {is_expected.to be == "my_span"}
 		end
+		
+		describe '#[]=' do
+			before {span["my_key"] = "tag_value"}
+
+			subject(:value) {span["my_key"]}
+
+			it {is_expected.to be == "tag_value"}
+		end
 	end
 	
 	describe Datadog::Tracing::TraceOperation do


### PR DESCRIPTION
This was previously supported, I mistakenly thought it was tested, but it wasn't, and then after removing it, tests still passed, so I assumed `ddtrace` implemented it.

I followed up here for further discussion: https://github.com/DataDog/dd-trace-rb/issues/2075

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
